### PR TITLE
Fix ChangeBPM in legacy chart parser + allow Psych sectionBeats

### DIFF
--- a/scripts/resources/chart_formats/funkin_legacy_chart.gd
+++ b/scripts/resources/chart_formats/funkin_legacy_chart.gd
@@ -38,6 +38,7 @@ func parse() -> Chart:
 		if section.mustHitSection != must_hit:
 			must_hit = section.mustHitSection
 			chart.events.push_back(CameraPan.new(time, int(not must_hit)))
+		var section_length: float = section.get("sectionBeats", 4.0);
 		var beat_delta: float = 60.0 / bpm
 		for note: Array in section.sectionNotes:
 			if int(note[1]) < 0:
@@ -59,8 +60,8 @@ func parse() -> Chart:
 			
 			chart.notes.push_back(note_data)
 		
-		beat += 4.0
-		time += 4.0 * beat_delta
+		beat += section_length
+		time += section_length * beat_delta
 	
 	Chart.sort_chart_notes(chart)
 	var stacked_notes := Chart.remove_stacked_notes(chart)

--- a/scripts/resources/chart_formats/funkin_legacy_chart.gd
+++ b/scripts/resources/chart_formats/funkin_legacy_chart.gd
@@ -32,6 +32,12 @@ func parse() -> Chart:
 	chart.events.push_back(CameraPan.new(time, int(not must_hit)))
 	
 	for section: Dictionary in data.notes:
+		if section.get('changeBPM', false) and section.get('bpm', -1.0) != bpm:
+			bpm = section.get('bpm', -1.0)
+			chart.events.push_back(BPMChange.new(time, bpm))
+		if section.mustHitSection != must_hit:
+			must_hit = section.mustHitSection
+			chart.events.push_back(CameraPan.new(time, int(not must_hit)))
 		var beat_delta: float = 60.0 / bpm
 		for note: Array in section.sectionNotes:
 			if int(note[1]) < 0:
@@ -52,13 +58,6 @@ func parse() -> Chart:
 				note_data.type = &'default'
 			
 			chart.notes.push_back(note_data)
-		
-		if section.get('changeBPM', false) and section.get('bpm', -1.0) != bpm:
-			bpm = section.get('bpm', -1.0)
-			chart.events.push_back(BPMChange.new(time, bpm))
-		if section.mustHitSection != must_hit:
-			must_hit = section.mustHitSection
-			chart.events.push_back(CameraPan.new(time, int(not must_hit)))
 		
 		beat += 4.0
 		time += 4.0 * beat_delta


### PR DESCRIPTION
in the legacy chart parser, change bpm stuff was in the wrong spot and fucking with timings of events etc. noticed with my chart editor made in the engine

After fix:
![image](https://github.com/user-attachments/assets/53e161f4-8c1b-4eb0-b2c2-c36e66798fee)

Before fix:
![image](https://github.com/user-attachments/assets/752ccd5e-faba-4fa8-bbec-87148e74d08c)

Also added sectionBeats support for psych charts cus uhh why not :P
