### PR TITLE
fix inaccuracy with color adjust in week 1 erect

### DIFF
--- a/scenes/game/assets/stages/stage_erect.gd
+++ b/scenes/game/assets/stages/stage_erect.gd
@@ -17,4 +17,4 @@ func _ready() -> void:
 	game.spectator.camera_offset.position.y -= 150.0
 	hue_character(game.player, 12.0, 0.0, 7.0, -23.0)
 	hue_character(game.spectator, -9.0, 0.0, -4.0, -30.0)
-	hue_character(game.opponent, -9.0, 0.0, -4.0, -30.0)
+	hue_character(game.opponent, -32.0, 0.0, -23.0, -33.0)


### PR DESCRIPTION
Fixes an inaccuracy with the week 1 color adjust to match how it looks in base game

# BEFORE

<img width="1281" height="722" alt="Screenshot from 2025-08-23 15-44-57" src="https://github.com/user-attachments/assets/b7e32d96-6378-410a-963e-3ae6fd3b5a88" />

# AFTER

<img width="1279" height="720" alt="Screenshot from 2025-08-23 15-46-38" src="https://github.com/user-attachments/assets/c8208047-be37-4fcd-8367-e86e5ddd0dd9" />

# BASE GAME FOR COMPARISON

<img width="1280" height="720" alt="screenshot-2025-08-23-15-56-57" src="https://github.com/user-attachments/assets/946efa57-f8b4-4a6f-8215-a0b494f71ea1" />

